### PR TITLE
Change camera name to lowercase in api call

### DIFF
--- a/Frigate Camera Notifications/Stable
+++ b/Frigate Camera Notifications/Stable
@@ -388,7 +388,7 @@ blueprint:
             - label: View Snapshot
               value: "{{base_url}}/api/frigate/notifications/{{id}}/snapshot.jpg"
             - label: View Stream
-              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera']}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'].lower()}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
             - label: Open Home Assistant (web)
               value: "{{base_url}}/lovelace"
             - label: Open Home Assistant (app)
@@ -418,7 +418,7 @@ blueprint:
             - label: View Snapshot
               value: "{{base_url}}/api/frigate/notifications/{{id}}/snapshot.jpg"
             - label: View Stream
-              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera']}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'].lower()}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
             - label: Open Home Assistant
               value: "{{base_url}}/lovelace"
           custom_value: true
@@ -438,7 +438,7 @@ blueprint:
             - label: View Snapshot
               value: "{{base_url}}/api/frigate/notifications/{{id}}/snapshot.jpg"
             - label: View Stream
-              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera']}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'].lower()}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
             - label: Open Home Assistant
               value: "{{base_url}}/lovelace"
           custom_value: true
@@ -460,7 +460,7 @@ blueprint:
             - label: View Snapshot
               value: "{{base_url}}/api/frigate/notifications/{{id}}/snapshot.jpg"
             - label: View Stream
-              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera']}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
+              value: "{{base_url}}/api/camera_proxy_stream/camera.{{trigger.payload_json['after']['camera'].lower()}}?token={{state_attr( 'camera.' ~ camera, 'access_token')}}"
             - label: Open Home Assistant
               value: "{{base_url}}/lovelace"
           custom_value: true


### PR DESCRIPTION
I had the issue that the View Stream action did not worked. I only got an "Not found" as a result. After some investigation, I recognized that I named the Camera with a captial letter ("Driveway") in Frigate. It seems like the API can only handle lowercase camera names. 

But maybe it is not a good idea to have the camera named with a capital letter in the beginning. Please let me know if I should rather change my camera name ;). 